### PR TITLE
sonarqube-dce: Update to 2025.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,39 @@
 # MAC0432-Helmfile
 
+Individually apply these releases to your cluster (ref: [https://helmfile.readthedocs.io/en/latest/#cli-reference](https://helmfile.readthedocs.io/en/latest/#cli-reference)):
+
 ```text
-# Apply this helmfile to your cluster
-helmfile -i apply -l=name=sonarqube
+helmfile -i apply -l=name=sonarqube-dce
+```
 
-# PostgreSQL localhost:5432
-k port-forward svc/sonarqube-postgresql 5432:5432
+Access apps running in the cluster (ref: [https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)):
 
-# SonarQube localhost:9020
-k port-forward svc/sonarqube-sonarqube-dce 9020:9000
+```text
+k port-forward svc/sonarqube-dce-postgresql 5432:5432
+```
+
+Thereafter, you should see something like:
+
+```text
+Forwarding from 127.0.0.1:5432 -> 5432
+Forwarding from [::1]:5432 -> 5432
+```
+
+In another tab, try `psql`; e.g.,
+
+```text
+➜  ~ psql -U sonarUser -d sonarDB -h localhost
+Password for user sonarUser:
+psql (14.17 (Homebrew), server 11.14)
+Type "help" for help.
+
+sonarDB=>
+```
+
+Et voilà! Port forwarding will, of course, also work for Prometheus, SonarQube; e.g.,
+
+```text
+k port-forward svc/kube-prometheus-stack-prometheus 9090:9090
+
+k port-forward svc/sonarqube-dce-sonarqube-dce 9000:9000
 ```

--- a/dev/sonarqube-dce/values.yaml
+++ b/dev/sonarqube-dce/values.yaml
@@ -1,19 +1,32 @@
-ApplicationNodes:
-  jwtSecret: "" # FIXME
+applicationNodes:
+  jwtSecret: "vzrZvlfYpkHqdxXdzPbuNvxkSToQsXRMxrc1zonlkl0="
+
+  resources:
+    limits:
+      memory: "2G"
+    requests:
+      cpu: "800m"
+      memory: "2G"
 
   sonarProperties:
     sonar.log.level: DEBUG
-    # sonar.security.realm: LDAP
 
-  sonarSecretProperties: sonarqube-dce-sonarqube-dce-secret-properties
-
-ingress-nginx:
-  enabled: true
-
-ingress:
-  enabled: true
-  hosts:
-    - name: sonarqube.aks.sonarsource.org
+    sonar.ce.javaOpts: "-Xmx2G"
+    sonar.web.javaOpts: "-Xmx512M"
 
 logging:
   jsonOutput: true
+
+monitoringPasscode: "123456"
+
+searchNodes:
+  resources:
+    limits:
+      memory: "3G"
+    requests:
+      cpu: "400m"
+      memory: "3G"
+
+  sonarProperties:
+    sonar.log.level: DEBUG
+    sonar.search.javaOpts: "-Xms2G -Xmx2G"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -24,6 +24,6 @@ releases:
 - name: sonarqube-dce
   namespace: sonarqube-dce
   chart: sonarqube/sonarqube-dce
-  version: 10.7.0+3598
+  version: 2025.1
   values:
   - dev/sonarqube-dce/values.yaml

--- a/secret.properties
+++ b/secret.properties
@@ -1,1 +1,0 @@
-sonar.log.level=TRACE


### PR DESCRIPTION
* Updated to `2025.1`, removed `ing`-related config, override `sonar.*.javaOpts`/resources for both app and search nodes;
* Updated README.